### PR TITLE
CW-3104_pairwiseid-pick-spentityid-not-idpentityid-ssp1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,11 @@
     },
     "config": {
         "allow-plugins": {
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "simplesamlphp/composer-xmlprovider-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/lib/Auth/Process/PairwiseID.php
+++ b/lib/Auth/Process/PairwiseID.php
@@ -222,26 +222,12 @@ class PairwiseID extends ProcessingFilter
     /**
      * Determine which SP entityID to bind a pairwise identifier to.
      *
-     * Applies when:
-     * - This code runs in an IdP-side processing context where the current relying party (SP) is represented in the
-     *   state (typically via `core:SP`), and
-     * - You want pairwise IDs to be stable per *ultimate/original* requester in proxy scenarios, not per intermediary.
-     *   If the request has been proxied, SimpleSAMLphp may populate `saml:RequesterID` with a requester chain; when
-     *   present, we take index 0 as the "original requester" entityID.
+     * Product position:
+     * - Pairwise IDs MUST be generated for the SP that is directly integrated with us (the immediate relying party),
+     *   not for an "ultimate/original requester" in proxied/hub scenarios.
      *
-     * Produces the "correct" pairwise ID only if:
-     * - `core:SP` contains the SP entityID for non-proxied flows, and
-     * - `saml:RequesterID[0]` is in fact the entityID you intend to pair against (commonly the original downstream SP).
-     *
-     * Will NOT create/construct the intended pairwise ID when:
-     * - Your deployment orders `saml:RequesterID` differently (e.g., nearest-first), so `[0]` refers to a proxy rather
-     *   than the downstream SP you mean to target.
-     * - A hub/broker intentionally omits or rewrites requester information; `saml:RequesterID` may be absent or may
-     *   identify only the broker, making downstream-SP pairwise IDs impossible or misleading.
-     * - Your intended semantics are "pairwise per immediate requester/proxy" (policy choice). In that case, preferring
-     *   `saml:RequesterID[0]` would be wrong; you would bind to the direct requester instead.
-     * - This runs in a context where neither `core:SP` nor `saml:RequesterID` are populated (different pipeline/entry
-     *   point), in which case we throw.
+     * In SimpleSAMLphp state, that direct SP is represented as:
+     * - `$state['Destination']['entityid']`
      *
      * @param array $state The SimpleSAMLphp state array for the current request.
      * @return string The selected SP entityID.
@@ -249,19 +235,14 @@ class PairwiseID extends ProcessingFilter
     private function extractSpEntityId(array $state): string
     {
         if (
-            isset($state['saml:RequesterID']) &&
-            is_array($state['saml:RequesterID']) &&
-            isset($state['saml:RequesterID'][0]) &&
-            is_string($state['saml:RequesterID'][0]) &&
-            $state['saml:RequesterID'][0] !== ''
+            isset($state['Destination']['entityid'])
+            && is_array($state['Destination'])
+            && is_string($state['Destination']['entityid'])
+            && $state['Destination']['entityid'] !== ''
         ) {
-            return $state['saml:RequesterID'][0];
+            return $state['Destination']['entityid'];
         }
 
-        if (isset($state['core:SP']) && is_string($state['core:SP']) && $state['core:SP'] !== '') {
-            return $state['core:SP'];
-        }
-
-        throw new \InvalidArgumentException('Missing SP entityID (core:SP or saml:RequesterID[0]).');
+        throw new \InvalidArgumentException('Missing SP entityID (Destination[entityid]).');
     }
 }

--- a/lib/Auth/Process/PairwiseID.php
+++ b/lib/Auth/Process/PairwiseID.php
@@ -90,10 +90,7 @@ class PairwiseID extends ProcessingFilter
             throw new \InvalidArgumentException('Missing or invalid attribute array in state.');
         }
 
-        if (!isset($request['Source']['entityid']) || !is_string($request['Source']['entityid'])) {
-            throw new \InvalidArgumentException('Missing or invalid Source/entityid in state.');
-        }
-
+        $spEntityId = $this->extractSpEntityId($request);
         $secretSalt = $this->getSecretSalt();
 
         if (empty($secretSalt)) {
@@ -103,7 +100,7 @@ class PairwiseID extends ProcessingFilter
         $pairwiseId = $this->generatePairwiseId(
             $request['Attributes'],
             $this->attribute,
-            (string)$request['Source']['entityid'],
+            $spEntityId,
             $secretSalt,
             $this->algorithm,
             $this->scope,
@@ -220,5 +217,51 @@ class PairwiseID extends ProcessingFilter
             $b32 = $b32 . '@' . $scope;
         }
         return $b32;
+    }
+
+    /**
+     * Determine which SP entityID to bind a pairwise identifier to.
+     *
+     * Applies when:
+     * - This code runs in an IdP-side processing context where the current relying party (SP) is represented in the
+     *   state (typically via `core:SP`), and
+     * - You want pairwise IDs to be stable per *ultimate/original* requester in proxy scenarios, not per intermediary.
+     *   If the request has been proxied, SimpleSAMLphp may populate `saml:RequesterID` with a requester chain; when
+     *   present, we take index 0 as the "original requester" entityID.
+     *
+     * Produces the "correct" pairwise ID only if:
+     * - `core:SP` contains the SP entityID for non-proxied flows, and
+     * - `saml:RequesterID[0]` is in fact the entityID you intend to pair against (commonly the original downstream SP).
+     *
+     * Will NOT create/construct the intended pairwise ID when:
+     * - Your deployment orders `saml:RequesterID` differently (e.g., nearest-first), so `[0]` refers to a proxy rather
+     *   than the downstream SP you mean to target.
+     * - A hub/broker intentionally omits or rewrites requester information; `saml:RequesterID` may be absent or may
+     *   identify only the broker, making downstream-SP pairwise IDs impossible or misleading.
+     * - Your intended semantics are "pairwise per immediate requester/proxy" (policy choice). In that case, preferring
+     *   `saml:RequesterID[0]` would be wrong; you would bind to the direct requester instead.
+     * - This runs in a context where neither `core:SP` nor `saml:RequesterID` are populated (different pipeline/entry
+     *   point), in which case we throw.
+     *
+     * @param array $state The SimpleSAMLphp state array for the current request.
+     * @return string The selected SP entityID.
+     */
+    private function extractSpEntityId(array $state): string
+    {
+        if (
+            isset($state['saml:RequesterID']) &&
+            is_array($state['saml:RequesterID']) &&
+            isset($state['saml:RequesterID'][0]) &&
+            is_string($state['saml:RequesterID'][0]) &&
+            $state['saml:RequesterID'][0] !== ''
+        ) {
+            return $state['saml:RequesterID'][0];
+        }
+
+        if (isset($state['core:SP']) && is_string($state['core:SP']) && $state['core:SP'] !== '') {
+            return $state['core:SP'];
+        }
+
+        throw new \InvalidArgumentException('Missing SP entityID (core:SP or saml:RequesterID[0]).');
     }
 }

--- a/tests/lib/Auth/Process/PairwiseIDTest.php
+++ b/tests/lib/Auth/Process/PairwiseIDTest.php
@@ -19,14 +19,9 @@ class PairwiseIDTest extends TestCase
         'Attributes' => [
             'uid' => ['774333']
         ],
-        'Destination' =>
-            [
-                'entityid' => 'https://somesp.edugain.example.edu/sp'
-            ],
-        'Source' =>
-            [
-                'entityid' => 'https://idp.example.edu/shibboleth'
-            ]
+        // Pairwise ID is computed per SP; in SSP state this is typically "core:SP"
+        // (or "saml:RequesterID[0]" for proxied).
+        'core:SP' => 'https://somesp.edugain.example.edu/sp',
     ];
 
     public function testNoConfigOptions(): void
@@ -39,8 +34,8 @@ class PairwiseIDTest extends TestCase
         $pairwiseId->process($localState);
 
         $localState = $this->state;
-        unset($localState['Source']);
-        $this->expectExceptionMessage('Missing or invalid Source/entityid in state.');
+        unset($localState['core:SP']);
+        $this->expectExceptionMessage('Missing SP entityID (core:SP or saml:RequesterID[0]).');
         $pairwiseId->process($localState);
     }
 
@@ -85,10 +80,10 @@ class PairwiseIDTest extends TestCase
         $this->assertArrayHasKey(PairwiseID::PAIRWISEID_ATTR_NAME, $localState['Attributes']);
         $this->assertStringEndsWith(
             '@example.com',
-            $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]
+            $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0],
         );
 
-        $expectedPairwiseId = 'XEFBRGW7UTQJ6EKRXF6Q4K6FOQG32ZX3@example.com';
+        $expectedPairwiseId = 'B7VDEFQKNFXREJWWRDH3FKXBU4S3YGOY@example.com';
 
         $this->assertEquals($expectedPairwiseId, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
     }
@@ -134,7 +129,7 @@ class PairwiseIDTest extends TestCase
         $actual = $pairwise->generatePairwiseId($attributes, 'uid', $sp, $salt, 'hmac-sha256', $scope);
 
         $this->assertSame(
-        // Precalculate the value and hard code it here to avoid any potential changes in the algorithm
+            // Precalculate the value and hard code it here to avoid any potential changes in the algorithm
             "FYTB5UBFURYSJWUEEP6DHB6BKSLVROK2OHWQKCVLBMSQQW2URWHA@example.org",
             $actual,
             'HMAC-SHA256 pairwise-id mismatch',
@@ -214,7 +209,7 @@ class PairwiseIDTest extends TestCase
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Could not retrieve the required option 'algorithm'");
-        $pairwise = new PairwiseID($config, null);
+        new PairwiseID($config, null);
     }
 
     public function testAlgorithmsProduceDifferentOutputs(): void
@@ -231,5 +226,72 @@ class PairwiseIDTest extends TestCase
         $hmac = $pairwise->generatePairwiseId($attributes, 'uid', $sp, $salt, 'hmac-sha256', $scope);
 
         $this->assertNotSame($sha1, $hmac, 'SHA-1 and HMAC-SHA256 outputs must differ');
+    }
+
+    public function testMissingSpEntityIdThrows(): void
+    {
+        $pairwise = new PairwiseID($this->config, null);
+
+        $localState = $this->state;
+        unset($localState['core:SP']);
+        unset($localState['saml:RequesterID']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing SP entityID (core:SP or saml:RequesterID[0]).');
+        $pairwise->process($localState);
+    }
+
+    public function testRequesterIdTakesPrecedenceOverCoreSp(): void
+    {
+        $pairwise = $this->getMockBuilder(PairwiseID::class)
+            ->setConstructorArgs([$this->config, null])
+            ->onlyMethods(['getSecretSalt'])
+            ->getMock();
+
+        $pairwise->method('getSecretSalt')->willReturn('secretsalt');
+
+        $localState = $this->state;
+        $localState['core:SP'] = 'https://core-sp.example.org/sp';
+        $localState['saml:RequesterID'] = ['https://requester-sp.example.org/sp'];
+
+        $pairwise->process($localState);
+
+        $expected = $pairwise->generatePairwiseId(
+            ['uid' => ['774333']],
+            'uid',
+            'https://requester-sp.example.org/sp',
+            'secretsalt',
+            'sha1',
+            'example.com',
+        );
+
+        $this->assertSame($expected, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
+    }
+
+    public function testMalformedRequesterIdFallsBackToCoreSp(): void
+    {
+        $pairwise = $this->getMockBuilder(PairwiseID::class)
+            ->setConstructorArgs([$this->config, null])
+            ->onlyMethods(['getSecretSalt'])
+            ->getMock();
+
+        $pairwise->method('getSecretSalt')->willReturn('secretsalt');
+
+        $localState = $this->state;
+        $localState['core:SP'] = 'https://core-sp.example.org/sp';
+        $localState['saml:RequesterID'] = 'not-an-array';
+
+        $pairwise->process($localState);
+
+        $expected = $pairwise->generatePairwiseId(
+            ['uid' => ['774333']],
+            'uid',
+            'https://core-sp.example.org/sp',
+            'secretsalt',
+            'sha1',
+            'example.com',
+        );
+
+        $this->assertSame($expected, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
     }
 }

--- a/tests/lib/Auth/Process/PairwiseIDTest.php
+++ b/tests/lib/Auth/Process/PairwiseIDTest.php
@@ -19,8 +19,11 @@ class PairwiseIDTest extends TestCase
         'Attributes' => [
             'uid' => ['774333']
         ],
-        // Pairwise ID is computed per SP; in SSP state this is typically "core:SP"
-        // (or "saml:RequesterID[0]" for proxied).
+        // Pairwise ID is computed per *directly integrated* SP; in SSP IdP state this is Destination[entityid].
+        'Destination' => [
+            'entityid' => 'https://somesp.edugain.example.edu/sp',
+        ],
+        // Kept only for legacy/back-compat state shape; no longer used for pairwise-id selection.
         'core:SP' => 'https://somesp.edugain.example.edu/sp',
     ];
 
@@ -34,8 +37,8 @@ class PairwiseIDTest extends TestCase
         $pairwiseId->process($localState);
 
         $localState = $this->state;
-        unset($localState['core:SP']);
-        $this->expectExceptionMessage('Missing SP entityID (core:SP or saml:RequesterID[0]).');
+        unset($localState['Destination']);
+        $this->expectExceptionMessage('Missing SP entityID (Destination[entityid]).');
         $pairwiseId->process($localState);
     }
 
@@ -72,7 +75,6 @@ class PairwiseIDTest extends TestCase
      */
     public function testPairwiseID(): void
     {
-
         $pairwiseId = new PairwiseID($this->config, null);
         $localState = $this->state;
 
@@ -146,7 +148,6 @@ class PairwiseIDTest extends TestCase
      */
     public function testPairwiseIDFailOnEmptyAttribute(): void
     {
-
         $pairwiseId = new PairwiseID($this->config, null);
         $localState = $this->state;
         unset($localState['Attributes']['uid']);
@@ -228,20 +229,7 @@ class PairwiseIDTest extends TestCase
         $this->assertNotSame($sha1, $hmac, 'SHA-1 and HMAC-SHA256 outputs must differ');
     }
 
-    public function testMissingSpEntityIdThrows(): void
-    {
-        $pairwise = new PairwiseID($this->config, null);
-
-        $localState = $this->state;
-        unset($localState['core:SP']);
-        unset($localState['saml:RequesterID']);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing SP entityID (core:SP or saml:RequesterID[0]).');
-        $pairwise->process($localState);
-    }
-
-    public function testRequesterIdTakesPrecedenceOverCoreSp(): void
+    public function testDestinationEntityIdIsUsedEvenIfCoreSpOrRequesterIdPresent(): void
     {
         $pairwise = $this->getMockBuilder(PairwiseID::class)
             ->setConstructorArgs([$this->config, null])
@@ -251,6 +239,7 @@ class PairwiseIDTest extends TestCase
         $pairwise->method('getSecretSalt')->willReturn('secretsalt');
 
         $localState = $this->state;
+        $localState['Destination']['entityid'] = 'https://destination-sp.example.org/sp';
         $localState['core:SP'] = 'https://core-sp.example.org/sp';
         $localState['saml:RequesterID'] = ['https://requester-sp.example.org/sp'];
 
@@ -259,7 +248,7 @@ class PairwiseIDTest extends TestCase
         $expected = $pairwise->generatePairwiseId(
             ['uid' => ['774333']],
             'uid',
-            'https://requester-sp.example.org/sp',
+            'https://destination-sp.example.org/sp',
             'secretsalt',
             'sha1',
             'example.com',
@@ -268,7 +257,7 @@ class PairwiseIDTest extends TestCase
         $this->assertSame($expected, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
     }
 
-    public function testMalformedRequesterIdFallsBackToCoreSp(): void
+    public function testPairwiseIdChangesWhenDestinationEntityIdChanges(): void
     {
         $pairwise = $this->getMockBuilder(PairwiseID::class)
             ->setConstructorArgs([$this->config, null])
@@ -277,21 +266,36 @@ class PairwiseIDTest extends TestCase
 
         $pairwise->method('getSecretSalt')->willReturn('secretsalt');
 
-        $localState = $this->state;
-        $localState['core:SP'] = 'https://core-sp.example.org/sp';
-        $localState['saml:RequesterID'] = 'not-an-array';
+        $stateOne = $this->state;
+        $stateOne['Destination']['entityid'] = 'https://destination-one.example.org/sp';
+        $pairwise->process($stateOne);
+        $valueOne = $stateOne['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0];
 
-        $pairwise->process($localState);
+        $stateTwo = $this->state;
+        $stateTwo['Destination']['entityid'] = 'https://destination-two.example.org/sp';
+        $pairwise->process($stateTwo);
+        $valueTwo = $stateTwo['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0];
 
-        $expected = $pairwise->generatePairwiseId(
+        $this->assertNotSame($valueOne, $valueTwo, 'Pairwise ID must change when Destination[entityid] changes');
+
+        $expectedOne = $pairwise->generatePairwiseId(
             ['uid' => ['774333']],
             'uid',
-            'https://core-sp.example.org/sp',
+            'https://destination-one.example.org/sp',
+            'secretsalt',
+            'sha1',
+            'example.com',
+        );
+        $expectedTwo = $pairwise->generatePairwiseId(
+            ['uid' => ['774333']],
+            'uid',
+            'https://destination-two.example.org/sp',
             'secretsalt',
             'sha1',
             'example.com',
         );
 
-        $this->assertSame($expected, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
+        $this->assertSame($expectedOne, $valueOne);
+        $this->assertSame($expectedTwo, $valueTwo);
     }
 }

--- a/tests/lib/Auth/Process/PairwiseIDTest.php
+++ b/tests/lib/Auth/Process/PairwiseIDTest.php
@@ -229,34 +229,6 @@ class PairwiseIDTest extends TestCase
         $this->assertNotSame($sha1, $hmac, 'SHA-1 and HMAC-SHA256 outputs must differ');
     }
 
-    public function testDestinationEntityIdIsUsedEvenIfCoreSpOrRequesterIdPresent(): void
-    {
-        $pairwise = $this->getMockBuilder(PairwiseID::class)
-            ->setConstructorArgs([$this->config, null])
-            ->onlyMethods(['getSecretSalt'])
-            ->getMock();
-
-        $pairwise->method('getSecretSalt')->willReturn('secretsalt');
-
-        $localState = $this->state;
-        $localState['Destination']['entityid'] = 'https://destination-sp.example.org/sp';
-        $localState['core:SP'] = 'https://core-sp.example.org/sp';
-        $localState['saml:RequesterID'] = ['https://requester-sp.example.org/sp'];
-
-        $pairwise->process($localState);
-
-        $expected = $pairwise->generatePairwiseId(
-            ['uid' => ['774333']],
-            'uid',
-            'https://destination-sp.example.org/sp',
-            'secretsalt',
-            'sha1',
-            'example.com',
-        );
-
-        $this->assertSame($expected, $localState['Attributes'][PairwiseID::PAIRWISEID_ATTR_NAME][0]);
-    }
-
     public function testPairwiseIdChangesWhenDestinationEntityIdChanges(): void
     {
         $pairwise = $this->getMockBuilder(PairwiseID::class)


### PR DESCRIPTION
Fix pairwise-id SP entityID extraction + tests